### PR TITLE
Fixing Return Shape

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -113,9 +113,6 @@ def get_data(cik, value_tags, data_name, min_year=0, min_quarter=0, max_year=300
                 value_data = new_rev_data if value_data is None else np.concatenate((value_data, new_rev_data))
         except HttpError:
             pass
-    # Filter data and make it unique as the above can return double counts
-    _, unique_indices = np.unique(value_data.astype(str)[:, 0], return_index=True, axis=0)
-    value_data = np.take(value_data, unique_indices, 0)
     # Precisely filter value data according to given year and quarter constraints
     value_data = np.fromiter(
         (x for x in value_data if is_in_date_bound(x[0], min_year, min_quarter, max_year, max_quarter)), dtype=value_data.dtype)


### PR DESCRIPTION
Currently we return a weird 1D Numpy array where all the column names are one element and all the np arrays for each quarter are a single element as well. Issue was making the final value data unique after all the data jargon words were collected sequentially. 