### PR TITLE
Adding get_dates + expanding data search

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import utils as ut
+import numpy as np
 
 """
 main.py - The public facing script which includes the main public class (FinData) and all the public, and useful, methods
@@ -46,3 +47,9 @@ class FinData:
         """
         cik = self._ticker_cik_map[ticker]
         return ut.get_data(cik, self._revenue_jargon, 'Revenue', start_year, start_quarter, end_year, end_quarter)
+
+    def get_dates(self, ticker, start_year=0, start_quarter=0, end_year=3000, end_quarter=5):
+        cik = self._ticker_cik_map[ticker]
+        raw_data = ut.get_data(cik, self._revenue_jargon, None, start_year, start_quarter, end_year, end_quarter)
+        filtered_data = np.delete(raw_data, 1, 1)
+        return filtered_data

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ class FinData:
 
     def get_revenue(self, ticker, start_year=0, start_quarter=0, end_year=3000, end_quarter=5):
         """
-        get_revenue - Returns the revenue for the provided ticker in the optional date bounds. Works off of SEC 10-Q
+        get_revenue - Returns the revenue for the provided ticker in the optional date bounds. Works off of SEC 10-Q/A
         and 10-K fillings so for some companies, notably banks, the function wont be able to return revenue
         :param ticker: The stock market ticker identifying your company of interest as a string.
         :param start_year: The companies financial year you want to start data collection from as an integer
@@ -53,7 +53,7 @@ class FinData:
     def get_dates(self, ticker, start_year=0, start_quarter=0, end_year=3000, end_quarter=5):
         """
         get_dates - Returns the exact dates each financial quarter, as defined by the company, falls into. Works off
-        of SEC 10-Q and 10-K fillings so for some companies, notably banks, the function wont be able to return dates
+        of SEC 10-Q/A and 10-K fillings so for some companies, notably banks, the function wont be able to return dates
         :param ticker: The stock market ticker identifying your company of interest as a string.
         :param start_year: The companies financial year you want to start data collection from as an integer
         :param start_quarter: The companies financial quarter you want to start data collection from as an integer

--- a/main.py
+++ b/main.py
@@ -36,20 +36,35 @@ class FinData:
 
     def get_revenue(self, ticker, start_year=0, start_quarter=0, end_year=3000, end_quarter=5):
         """
-        get_revenue - Retrieves the revenue for the provided ticker in the optional date bounds. Works off of SEC 10-Q
+        get_revenue - Returns the revenue for the provided ticker in the optional date bounds. Works off of SEC 10-Q
         and 10-K fillings so for some companies, notably banks, the function wont be able to return revenue
         :param ticker: The stock market ticker identifying your company of interest as a string.
         :param start_year: The companies financial year you want to start data collection from as an integer
         :param start_quarter: The companies financial quarter you want to start data collection from as an integer
         :param end_year: The companies financial year you want to end data collection with as an integer (inclusive)
         :param end_quarter: The companies financial quarter you want to end data collection with as an integer (inclusive)
-        :return: A numpy array with the first row being column names and the remainder being revenue data by quarter.
+        :return: A numpy array with the first row being column names and the remainder being revenue data by quarter
+        with the quarters being according to the companies financial calendar and may greatly differ from the normal
+        calendar
         """
         cik = self._ticker_cik_map[ticker]
         return ut.get_data(cik, self._revenue_jargon, 'Revenue', start_year, start_quarter, end_year, end_quarter)
 
     def get_dates(self, ticker, start_year=0, start_quarter=0, end_year=3000, end_quarter=5):
+        """
+        get_dates - Returns the exact dates each financial quarter, as defined by the company, falls into. Works off
+        of SEC 10-Q and 10-K fillings so for some companies, notably banks, the function wont be able to return dates
+        :param ticker: The stock market ticker identifying your company of interest as a string.
+        :param start_year: The companies financial year you want to start data collection from as an integer
+        :param start_quarter: The companies financial quarter you want to start data collection from as an integer
+        :param end_year: The companies financial year you want to end data collection with as an integer (inclusive)
+        :param end_quarter: The companies financial quarter you want to end data collection with as an integer (inclusive)
+        :return: A numpy array with the first row being column names and the remainder being the start/end dates by
+        quarter with the quarters being according to the companies financial calendar and may greatly differ from the
+        normal calendar
+        """
         cik = self._ticker_cik_map[ticker]
+        # To maximize code re-use I am using the same set-up as with get_revenues and then deleting the revenues after
         raw_data = ut.get_data(cik, self._revenue_jargon, None, start_year, start_quarter, end_year, end_quarter)
         filtered_data = np.delete(raw_data, 1, 1)
         return filtered_data

--- a/test_main.py
+++ b/test_main.py
@@ -20,3 +20,20 @@ class TestFinData(TestCase):
         self.assertAlmostEqual(particular_quarter[1]/1e9, 78.4, 1, "Checking revenue is as reported by Apple")
         self.assertEqual(particular_quarter[2], datetime.datetime(2016, 9, 25), "Checking start date for quarter")
         self.assertEqual(particular_quarter[3], datetime.datetime(2016, 12, 31), "Checking end date for quarter")
+
+    def test_get_dates(self):
+        date_data = self.fin_data_test_subject.get_dates('MSFT', 2011, 1, 2017, 4)
+        self.assertEqual(date_data.shape, (29, 3), "28 quarters between 2011 and 2017 plus the column names")
+        # Relying on data from:
+        # https://www.microsoft.com/en-us/Investor/earnings/FY-2010-Q4/press-release-webcast
+        # https://www.microsoft.com/en-us/Investor/earnings/FY-2011-Q1/press-release-webcast
+        # https://www.microsoft.com/en-us/Investor/earnings/FY-2013-Q3/press-release-webcast
+        # https://www.microsoft.com/en-us/Investor/earnings/FY-2013-Q4/press-release-webcast
+        # https://www.microsoft.com/en-us/Investor/earnings/FY-2017-Q3/press-release-webcast
+        # https://www.microsoft.com/en-us/Investor/earnings/FY-2017-Q4/press-release-webcast
+        self.assertEqual(date_data[1][1], datetime.datetime(2010, 7, 1), "Checking the start of the array")
+        self.assertEqual(date_data[1][2], datetime.datetime(2010, 9, 30), "Checking the start of the array")
+        self.assertEqual(date_data[12][1], datetime.datetime(2013, 4, 1), "Checking the middle of the array")
+        self.assertEqual(date_data[12][2], datetime.datetime(2013, 6, 30), "Checking the middle of the array")
+        self.assertEqual(date_data[-1][1], datetime.datetime(2017, 4, 1), "Checking the end of the array")
+        self.assertEqual(date_data[-1][2], datetime.datetime(2017, 6, 30), "Checking the end of the array")

--- a/test_main.py
+++ b/test_main.py
@@ -11,7 +11,7 @@ class TestFinData(TestCase):
         self.fin_data_test_subject = FinData()
 
     def test_get_revenue(self):
-        revenue_data = self.fin_data_test_subject.get_revenue('AAPL',2010,1,2022,4)
+        revenue_data = self.fin_data_test_subject.get_revenue('AAPL', 2010, 1, 2022, 4)
         self.assertEqual(revenue_data.shape, (53, 4), "52 quarters between 2010 and 2022 plus the column names")
         # Relying on data from https://www.apple.com/newsroom/2017/01/apple-reports-record-first-quarter-results/ and
         # https://www.apple.com/newsroom/2016/10/apple-reports-fourth-quarter-results/

--- a/utils.py
+++ b/utils.py
@@ -86,8 +86,8 @@ def get_spec_data_given_url(url, min_year=0, max_year=3000):
         return item["form"] == "10-K" and "fy" in item and "fp" in item and min_year <= int(item["fy"]) <= max_year and\
         330 < (dt.fromisoformat(item["end"]) - dt.fromisoformat(item["start"])).days < 380
     def qr_is_valid(item):
-        return item["form"] in "10-Q/A" and "fy" in item and "fp" in item and min_year <= int(item["fy"]) <= max_year and\
-               60 < (dt.fromisoformat(item["end"]) - dt.fromisoformat(item["start"])).days < 100
+        return item["form"] in "10-Q/A" and "fy" in item and "fp" in item and min_year <= int(item["fy"]) <= max_year \
+        and 60 < (dt.fromisoformat(item["end"]) - dt.fromisoformat(item["start"])).days < 100
 
     # Create tables of quarterly and yearly revenues by parsng the raw output
     yearly_revenue = {str(item["fy"]): item["val"] for item in raw_output["units"]["USD"] if yr_is_valid(item)}

--- a/utils.py
+++ b/utils.py
@@ -86,8 +86,9 @@ def get_spec_data_given_url(url, min_year=0, max_year=3000):
         return item["form"] == "10-K" and "fy" in item and "fp" in item and min_year <= int(item["fy"]) <= max_year and\
         330 < (dt.fromisoformat(item["end"]) - dt.fromisoformat(item["start"])).days < 380
     def qr_is_valid(item):
-        return item["form"] == "10-Q" and "fy" in item and "fp" in item and min_year <= int(item["fy"]) <= max_year and\
-        60 < (dt.fromisoformat(item["end"]) - dt.fromisoformat(item["start"])).days < 100
+        return item["form"] == "10-Q" or item["form"] == "10-Q/A" and "fy" in item and "fp" in item and \
+               min_year <= int(item["fy"]) <= max_year and \
+               60 < (dt.fromisoformat(item["end"]) - dt.fromisoformat(item["start"])).days < 100
 
     # Create tables of quarterly and yearly revenues by parsng the raw output
     yearly_revenue = {str(item["fy"]): item["val"] for item in raw_output["units"]["USD"] if yr_is_valid(item)}

--- a/utils.py
+++ b/utils.py
@@ -86,8 +86,7 @@ def get_spec_data_given_url(url, min_year=0, max_year=3000):
         return item["form"] == "10-K" and "fy" in item and "fp" in item and min_year <= int(item["fy"]) <= max_year and\
         330 < (dt.fromisoformat(item["end"]) - dt.fromisoformat(item["start"])).days < 380
     def qr_is_valid(item):
-        return item["form"] == "10-Q" or item["form"] == "10-Q/A" and "fy" in item and "fp" in item and \
-               min_year <= int(item["fy"]) <= max_year and \
+        return item["form"] in "10-Q/A" and "fy" in item and "fp" in item and min_year <= int(item["fy"]) <= max_year and\
                60 < (dt.fromisoformat(item["end"]) - dt.fromisoformat(item["start"])).days < 100
 
     # Create tables of quarterly and yearly revenues by parsng the raw output


### PR DESCRIPTION
Adding another public function that retrieves the quarter dates for every company as companies financial years and quarters are often different from normal years or even a normal interpretation of financial years. 
While testing this function I noticed some missing data and identified the cause to be a too strict constraint on what forms our data can come from so I eased the constraint.

Testing Plan:
- [x] Unit Tests Passing