### PR TITLE
get_cost_of_revenue + Overhaul on data collection (adding collection based on frames)

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ class FinData:
     # Defining fields to access and extract data from the SEC API
     _revenue_jargon = ["SalesRevenueNet", "RevenueFromContractWithCustomerExcludingAssessedTax", "SalesRevenueGoodsNet",
                        "Revenues", "RevenueNet", "RevenuesNet"]
+    _cor_jargon = ["CostOfGoodsAndServicesSold", "CostOfRevenue", "CostOfGoodsSold", "CostOfServicesSold"]
     _cik_map_url = "https://www.sec.gov/files/company_tickers.json"
     _ticker_cik_map = {}
     _name_cik_map = {}
@@ -68,3 +69,7 @@ class FinData:
         raw_data = ut.get_data(cik, self._revenue_jargon, None, start_year, start_quarter, end_year, end_quarter)
         filtered_data = np.delete(raw_data, 1, 1)
         return filtered_data
+
+    def get_cost_of_revenue(self, ticker, start_year=0, start_quarter=0, end_year=3000, end_quarter=5):
+        cik = self._ticker_cik_map[ticker]
+        return ut.get_data(cik, self._cor_jargon, 'Cost of Revenue', start_year, start_quarter, end_year, end_quarter)

--- a/test_main.py
+++ b/test_main.py
@@ -12,7 +12,7 @@ class TestFinData(TestCase):
 
     def test_get_revenue(self):
         revenue_data = self.fin_data_test_subject.get_revenue('AAPL', 2010, 1, 2022, 4)
-        self.assertEqual(revenue_data.shape, (53, 4), "52 quarters between 2010 and 2022 plus the column names")
+        self.assertEqual(revenue_data.shape, (53, 4), "52 quarters between SOY 2010 and EOY 2022 plus the column names")
         # Relying on data from https://www.apple.com/newsroom/2017/01/apple-reports-record-first-quarter-results/ and
         # https://www.apple.com/newsroom/2016/10/apple-reports-fourth-quarter-results/
         # Quarter picked at random
@@ -23,7 +23,7 @@ class TestFinData(TestCase):
 
     def test_get_dates(self):
         date_data = self.fin_data_test_subject.get_dates('MSFT', 2011, 1, 2017, 4)
-        self.assertEqual(date_data.shape, (29, 3), "28 quarters between 2011 and 2017 plus the column names")
+        self.assertEqual(date_data.shape, (29, 3), "28 quarters between SOY 2011 and EOY 2017 plus the column names")
         # Relying on data from:
         # https://www.microsoft.com/en-us/Investor/earnings/FY-2010-Q4/press-release-webcast
         # https://www.microsoft.com/en-us/Investor/earnings/FY-2011-Q1/press-release-webcast
@@ -37,3 +37,7 @@ class TestFinData(TestCase):
         self.assertEqual(date_data[12][2], datetime.datetime(2013, 6, 30), "Checking the middle of the array")
         self.assertEqual(date_data[-1][1], datetime.datetime(2017, 4, 1), "Checking the end of the array")
         self.assertEqual(date_data[-1][2], datetime.datetime(2017, 6, 30), "Checking the end of the array")
+
+    def test_get_cost_of_revenue(self):
+        cor_data = self.fin_data_test_subject.get_cost_of_revenue('WMT', 2013, 2, 2019, 4)
+        self.assertEqual(cor_data.shape, (28, 4), "27 quarters between 2013Q2 and EOY 2019 plus the column names")

--- a/test_main.py
+++ b/test_main.py
@@ -41,3 +41,10 @@ class TestFinData(TestCase):
     def test_get_cost_of_revenue(self):
         cor_data = self.fin_data_test_subject.get_cost_of_revenue('WMT', 2013, 2, 2019, 4)
         self.assertEqual(cor_data.shape, (28, 4), "27 quarters between 2013Q2 and EOY 2019 plus the column names")
+        # Relying on data from:
+        # https://s201.q4cdn.com/262069030/files/doc_financials/2016/q4/Q4-FY16-press-release-final.pdf
+        # https://s201.q4cdn.com/262069030/files/doc_financials/2016/q3/Press-Release.pdf
+        particular_quarter = cor_data[cor_data[:, 0] == "2016Q4"][0]
+        self.assertAlmostEqual(particular_quarter[1] / 1e9, 96.999, 3, "Checking Cost of Rev is as reported by Walmart")
+        self.assertEqual(particular_quarter[2], datetime.datetime(2015, 11, 1), "Checking start date for quarter")
+        self.assertEqual(particular_quarter[3], datetime.datetime(2016, 1, 31), "Checking end date for quarter")


### PR DESCRIPTION
Set up of get_cost_of_revenue and massive overhaul of data collection with a secondary collector based on frames if there is insufficient data. Frames are one of the values the SEC returns but we often deem it too off the normal company calendar but with this addition we only add it if that quarter cannot be found our conventional way making our concern about this largely go away.

Testing Plan:

- [x] Unit Tests Passing