### PR TITLE
Add get_gross_profit

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ class FinData:
     _revenue_jargon = ["SalesRevenueNet", "RevenueFromContractWithCustomerExcludingAssessedTax", "SalesRevenueGoodsNet",
                        "Revenues", "RevenueNet", "RevenuesNet"]
     _cor_jargon = ["CostOfGoodsAndServicesSold", "CostOfRevenue", "CostOfGoodsSold", "CostOfServicesSold"]
+    _gross_profit_jargon = ["GrossProfit"]
     _cik_map_url = "https://www.sec.gov/files/company_tickers.json"
     _ticker_cik_map = {}
     _name_cik_map = {}
@@ -84,5 +85,9 @@ class FinData:
         the cost of revenue with the quarters being according to the companies financial calendar and may greatly differ
         from the normal calendar
         """
+        cik = self._ticker_cik_map[ticker]
+        return ut.get_data(cik, self._cor_jargon, 'Cost of Revenue', start_year, start_quarter, end_year, end_quarter)
+
+    def get_gross_profit(self, ticker, start_year=0, start_quarter=0, end_year=3000, end_quarter=5):
         cik = self._ticker_cik_map[ticker]
         return ut.get_data(cik, self._cor_jargon, 'Cost of Revenue', start_year, start_quarter, end_year, end_quarter)

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ class FinData:
     _revenue_jargon = ["SalesRevenueNet", "RevenueFromContractWithCustomerExcludingAssessedTax", "SalesRevenueGoodsNet",
                        "Revenues", "RevenueNet", "RevenuesNet"]
     _cor_jargon = ["CostOfGoodsAndServicesSold", "CostOfRevenue", "CostOfGoodsSold", "CostOfServicesSold"]
-    _gross_profit_jargon = ["GrossProfit"]
+    _g_profit_jargon = ["GrossProfit"]
     _cik_map_url = "https://www.sec.gov/files/company_tickers.json"
     _ticker_cik_map = {}
     _name_cik_map = {}
@@ -73,9 +73,10 @@ class FinData:
 
     def get_cost_of_revenue(self, ticker, start_year=0, start_quarter=0, end_year=3000, end_quarter=5):
         """
-        get_dates - Returns the exact dates each financial quarter, as defined by the company, falls into. Works off
-        of SEC 10-Q/A and 10-K fillings so for some companies, notably banks, the function won't be able to return
-        dates. Additionally, due to some companies' financial practices, not everyone documents strict cost of revenue
+        get_cost_of_revenue - Returns the exact dates each financial quarter, as defined by the company, falls into.
+        Works off SEC 10-Q/A and 10-K fillings so for some companies, notably banks, the function won't be able to
+        return dates. Additionally, due to some companies' financial practices, not everyone documents strict cost of
+        revenue
         :param ticker: The stock market ticker identifying your company of interest as a string.
         :param start_year: The company's financial year you want to start data collection from as an integer
         :param start_quarter: The company's financial quarter you want to start data collection from as an integer
@@ -89,5 +90,18 @@ class FinData:
         return ut.get_data(cik, self._cor_jargon, 'Cost of Revenue', start_year, start_quarter, end_year, end_quarter)
 
     def get_gross_profit(self, ticker, start_year=0, start_quarter=0, end_year=3000, end_quarter=5):
+        """
+        get_gross_profit - Returns the exact dates each financial quarter, as defined by the company, falls into. Works
+        off SEC 10-Q/A and 10-K fillings so for some companies, notably banks, the function won't be able to return
+        dates. Additionally, due to their financial practices, many companies don't record gross profit
+        :param ticker: The stock market ticker identifying your company of interest as a string.
+        :param start_year: The company's financial year you want to start data collection from as an integer
+        :param start_quarter: The company's financial quarter you want to start data collection from as an integer
+        :param end_year: The company's financial year you want to end data collection with as an integer (inclusive)
+        :param end_quarter: The company's financial quarter you want to end data collection with as an integer (inclusive)
+        :return: A numpy array with the first row being column names and the remainder being the quarter data along with
+        the gross profit with the quarters being according to the companies financial calendar and may greatly differ
+        from the normal calendar
+        """
         cik = self._ticker_cik_map[ticker]
-        return ut.get_data(cik, self._cor_jargon, 'Cost of Revenue', start_year, start_quarter, end_year, end_quarter)
+        return ut.get_data(cik, self._g_profit_jargon, 'Gross Profit', start_year, start_quarter, end_year, end_quarter)

--- a/test_main.py
+++ b/test_main.py
@@ -48,3 +48,7 @@ class TestFinData(TestCase):
         self.assertAlmostEqual(particular_quarter[1] / 1e9, 96.999, 3, "Checking Cost of Rev is as reported by Walmart")
         self.assertEqual(particular_quarter[2], datetime.datetime(2015, 11, 1), "Checking start date for quarter")
         self.assertEqual(particular_quarter[3], datetime.datetime(2016, 1, 31), "Checking end date for quarter")
+
+    def test_get_gross_profit(self):
+        gp_data = self.fin_data_test_subject.get_gross_profit('TSLA', 2014, 1, 2021, 3)
+        self.assertEqual(gp_data.shape, (32, 4), "31 quarters between SOY 2014 and 2021Q3 plus the column names")

--- a/test_main.py
+++ b/test_main.py
@@ -57,6 +57,7 @@ class TestFinData(TestCase):
         self.assertEqual(gp_data.shape, (32, 4), "31 quarters between SOY 2014 and 2021Q3 plus the column names")
         # Relying on data from:
         # https://tesla-cdn.thron.com/static/R3GJMT_TSLA_Q1_2021_Update_5KJWZA.pdf
+        # https://www.sec.gov/ix?doc=/Archives/edgar/data/815097/000081509720000030/ccl-20200229.htm
         particular_quarter = gp_data[gp_data[:, 0] == "2020Q1"][0]
         self.assertAlmostEqual(particular_quarter[1] / 1e9, 1.234, 3, "Checking Gross Profit as reported by Tesla")
         self.assertEqual(particular_quarter[2], datetime.datetime(2020, 1, 1), "Checking start date for quarter")

--- a/test_main.py
+++ b/test_main.py
@@ -6,6 +6,7 @@ from main import FinData
 main.py - Testing script containing unit tests for all the public facing methods in main.py
 """
 
+
 class TestFinData(TestCase):
     fin_data_test_subject = None
 

--- a/test_main.py
+++ b/test_main.py
@@ -2,6 +2,9 @@ import datetime
 from unittest import TestCase
 from main import FinData
 
+"""
+main.py - Testing script containing unit tests for all the public facing methods in main.py
+"""
 
 class TestFinData(TestCase):
     fin_data_test_subject = None
@@ -52,3 +55,9 @@ class TestFinData(TestCase):
     def test_get_gross_profit(self):
         gp_data = self.fin_data_test_subject.get_gross_profit('TSLA', 2014, 1, 2021, 3)
         self.assertEqual(gp_data.shape, (32, 4), "31 quarters between SOY 2014 and 2021Q3 plus the column names")
+        # Relying on data from:
+        # https://tesla-cdn.thron.com/static/R3GJMT_TSLA_Q1_2021_Update_5KJWZA.pdf
+        particular_quarter = gp_data[gp_data[:, 0] == "2020Q1"][0]
+        self.assertAlmostEqual(particular_quarter[1] / 1e9, 1.234, 3, "Checking Gross Profit as reported by Tesla")
+        self.assertEqual(particular_quarter[2], datetime.datetime(2020, 1, 1), "Checking start date for quarter")
+        self.assertEqual(particular_quarter[3], datetime.datetime(2020, 3, 31), "Checking end date for quarter")


### PR DESCRIPTION
Add the get_gross_profit function in main.py which retrieves a company's gross profit, if they include such information in their financials as many (majority) do not. 

Testing Plan:
- [x] Unit Tests Passed