### PR TITLE
Change Ratelimiter

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,10 @@
 import datetime
-import json
 from datetime import datetime as dt
 from math import isclose
 from ratelimit import limits
-import numpy as np
 import requests
+import json
+import numpy as np
 from exceptions import *
 
 """

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,10 @@
 import datetime
 from datetime import datetime as dt
-from math import isclose
 from ratelimit import limits
 import requests
 import json
 import numpy as np
+from math import isclose
 from exceptions import *
 
 """

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,10 @@
 import datetime
-from datetime import datetime as dt
-import requests
-from ratelimiter import RateLimiter
 import json
-import numpy as np
+from datetime import datetime as dt
 from math import isclose
+from ratelimit import limits
+import numpy as np
+import requests
 from exceptions import *
 
 """
@@ -40,7 +40,7 @@ def fill_financial_data(yearly_data, quarterly_data, allow_negatives):
 
 
 "Retrieves SEC data given the complete URL in a json format"
-@RateLimiter(max_calls=10, period=1)
+@limits(calls=10, period=1)
 def get_url_data(url):
     r = requests.get(url, headers={'User-Agent': 'Automated-Financial-Data-Library'})
     # Throw if the request was incorrect because of the revenue word


### PR DESCRIPTION
Changing ratelimiting library as the old one was no longer functioning for python 3.11 and above. The new library is also better documented and has alot more contributions and stars.
Testing Plan:
- [x] Unit tests passed